### PR TITLE
quickemu default disk size increse

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -498,7 +498,7 @@ function vm_boot() {
         fi
 
         if [ -z "${disk_size}" ]; then
-            disk_size="16G"
+            disk_size="32G"
         fi
         ;;
      kolibrios|reactos)


### PR DESCRIPTION
this increases the default disk size from 16 to 32, fixing issues #738  and #944