### PR TITLE
Fix USB input devices after macOS Sonoma update

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -563,6 +563,7 @@ function vm_boot() {
             NET_DEVICE="virtio-net"
             USB_HOST_PASSTHROUGH_CONTROLLER="nec-usb-xhci"
             GUEST_TWEAKS="${GUEST_TWEAKS} -global nec-usb-xhci.msi=off"
+            USB_CONTROLLER="xhci"
             ;;
         *)
             # Backwards compatibility if no macos_release is specified.


### PR DESCRIPTION
A recent macOS Sonoma update included a change to the handling of USB controllers that made the virtual keyboard and mouse inoperative. Changing the USB controller from ehci to xhci fixes it. This change also works for Big Sur and later, so the USB controller is set to xhci for Big Sur through Sonoma.